### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/languages/python/notes.py
+++ b/languages/python/notes.py
@@ -608,7 +608,7 @@ else:
 "" Libs & tools for DEVS !
 """"""""""""""""""""""""""
 pew > virtualenv # sandbox. To move an existing environment: virtualenv --relocatable $env
-pip # NEVER sudo !! > easyinstall - Distutils2 has been abandonned :( Check buildout/conda/bento/hashdist/pyinstaller for new projects or keep using setuptools: https://packaging.python.org
+pip # NEVER sudo !! > easyinstall - Distutils2 has been abandoned :( Check buildout/conda/bento/hashdist/pyinstaller for new projects or keep using setuptools: https://packaging.python.org
 pip --editable $path_or_git_url # Install a project in editable mode (i.e. setuptools "develop mode") from a local project path or a VCS url. FROM: S&M
 pip freeze > requirements.txt # dumps all the virtualenv dependencies
 pip install --user $USER --src . -r requirements.txt

--- a/misc/Software_Engineering/TheArchitectureOfOpenSourceApplications.md
+++ b/misc/Software_Engineering/TheArchitectureOfOpenSourceApplications.md
@@ -95,7 +95,7 @@ distributed hash tables aka consistent hash rings, various detailed forms of ran
 Yahoo's PNUTS relaxed consistency & relaxed availability, hinted handoff, Merkle tree, gossip protocol
 
 ## Python packaging by Tarek Ziadé
-- distutils2 > pip > distribute > setuptools > distutils BUT it has been abandonned :( Check zc.buildout/conda/bento/hashdist/pyinstaller for new projects or keep using setuptools: https://packaging.python.org
+- distutils2 > pip > distribute > setuptools > distutils BUT it has been abandoned :( Check zc.buildout/conda/bento/hashdist/pyinstaller for new projects or keep using setuptools: https://packaging.python.org
 - some old distutils issues: `python setup.py --name` may fails; `setup(requires=['ldap'])` is useless; PyPI may act as a SPOF; there is no way to remove installed files (there is `python setup.py install --record` but it is never used); if a dependency install fails or there is a dependency conflicts, the system can end up in a broken state...
 - Simple Index protocol and XML-RPC APIs
 - `dist-info` metadata of files installed, including a _RESOURCES_ file mapping project-root-relative files to paths in the system (e.g. /etc/, /var/...)


### PR DESCRIPTION
```
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
```
